### PR TITLE
work around bat bug when `--plain` is combined with `--pager`

### DIFF
--- a/src/pager/main.rs
+++ b/src/pager/main.rs
@@ -210,7 +210,7 @@ fn dump_prefetched_lines_and_exit(lines: Vec<Vec<u8>>, filetype: &str) -> ! {
 
     if !filetype.is_empty() && filetype != "pager" {
         let try_spawn_bat = std::process::Command::new("bat")
-            .arg("--plain")
+            .arg("--style=plain")
             .arg("--paging=never")
             .arg("--color=always")
             .arg(&format!("--language={}", filetype))


### PR DESCRIPTION
`bat` fails to acknowledge `--plain` when `--pager` is used after it, as reported in https://github.com/sharkdp/bat/issues/2731

Since `--plain` is just an alias for `--style=plain`, it can be used directly to work around the issue.