### PR TITLE
Make used temporary directory user-specific

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "term_size",
  "tokio",
  "tokio-util",
+ "users",
  "walkdir",
 ]
 
@@ -801,6 +802,16 @@ name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ log = "0.4.17"
 fern = "0.6.1"
 indoc = "1.0.8"
 clap = { version = "4.0.32", features = ["wrap_help", "derive", "env"] }
+users = "0.11.0"
 
 
 [build-dependencies]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -21,8 +21,7 @@ use tokio_util::compat::{
 };
 
 use std::{
-    path::Path,
-    process::ExitStatus
+    os::unix::fs::DirBuilderExt, path::Path, process::ExitStatus
 };
 
 
@@ -345,7 +344,7 @@ fn print_redirect_protection(tmp_dir: &Path) {
     let d = tmp_dir
         .join("DO-NOT-REDIRECT-OUTSIDE-OF-NVIM-TERM(--help[-W])");
 
-    if let Err(e) = std::fs::create_dir_all(&d) {
+    if let Err(e) = std::fs::DirBuilder::new().mode(0o700).recursive(true).create(&d) {
         panic!("Cannot create protection directory '{}': {e:?}", d.display())
     }
 

--- a/src/pager/context.rs
+++ b/src/pager/context.rs
@@ -180,6 +180,7 @@ pub mod gather_env {
 
 
 pub mod check_usage {
+    use std::os::unix::fs::DirBuilderExt;
 
     /// Contains data available after page was spawned from shell
     #[derive(Debug)]
@@ -256,9 +257,10 @@ pub mod check_usage {
     }
 
     fn create_temp_directory() -> std::path::PathBuf {
-        let d = std::env::temp_dir()
-            .join("neovim-page");
-        std::fs::create_dir_all(&d)
+        let d = std::env::temp_dir().join(&format!(
+            "neovim-page.{}", users::get_current_uid()
+        ));
+        std::fs::DirBuilder::new().mode(0o700).recursive(true).create(&d)
             .expect("Cannot create temporary directory for page");
         d
     }

--- a/src/pager/main.rs
+++ b/src/pager/main.rs
@@ -1021,7 +1021,9 @@ mod output_buffer_usage {
                 addr.clone()
             } else {
                 std::env::temp_dir()
-                    .join("neovim-page")
+                    .join(&format!(
+                        "neovim-page.{}", users::get_current_uid()
+                    ))
                     .join(&format!("socket-{}", &self.outp_ctx.page_id))
                     .to_string_lossy()
                     .to_string()

--- a/src/picker/context.rs
+++ b/src/picker/context.rs
@@ -1,6 +1,7 @@
 pub use env_context::Env;
 
 pub mod env_context {
+    use std::os::unix::fs::DirBuilderExt;
 
     #[derive(Debug)]
     pub struct Env {
@@ -44,8 +45,10 @@ pub mod env_context {
 
         let tmp_dir = {
             let d = std::env::temp_dir()
-                .join("neovim-page");
-            std::fs::create_dir_all(&d)
+                .join(&format!(
+                    "neovim-page.{}", users::get_current_uid()
+                ));
+            std::fs::DirBuilder::new().mode(0o700).recursive(true).create(&d)
                 .expect("Cannot create temporary directory for page");
             d
         };


### PR DESCRIPTION
In a multi-user setup, the `neovim-page` temporary directory leads to problems, as the second user will not have the necessary permissions for it to work, leading to a panic:

```
thread 'main' panicked at .../page-git/src/page/src/connection.rs:339:5:
Cannot connect to neovim: attempts=81, address="/tmp/neovim-page/socket-<...>", Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR fixes the panic by utilizing UID-specific temporary directories with fitting permissions.